### PR TITLE
use sensor rotation from gyro instead of driftable odometry rotation

### DIFF
--- a/subsystems/drivesubsystem.py
+++ b/subsystems/drivesubsystem.py
@@ -479,7 +479,7 @@ class DriveSubsystem(SubsystemBase):
         self.backRightModule.applyState(backRightState)
 
     def getRotation(self) -> Rotation2d:
-        return Rotation2d.fromDegrees(self.gyro.getYaw())
+        return Rotation2d.fromDegrees(-self.gyro.getYaw())
 
     def resetOdometryAtPosition(self, pose: Pose2d):
         self.odometry.resetPosition(

--- a/subsystems/drivesubsystem.py
+++ b/subsystems/drivesubsystem.py
@@ -615,7 +615,7 @@ class DriveSubsystem(SubsystemBase):
                 chassisSpeeds.vx,
                 chassisSpeeds.vy,
                 chassisSpeeds.omega,
-                self.odometry.getPose().rotation(),
+                self.getRotation(),
             )
         elif coordinateMode is DriveSubsystem.CoordinateMode.TargetRelative:
             if SmartDashboard.getBoolean(


### PR DESCRIPTION
as title states, during matches last year a driver encountered a "drift"
this drift is reproducible in simulation, which rules out sensor malfunction
this fix removes the drift issue during field relative drive